### PR TITLE
Feature/docker setup

### DIFF
--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,13 +1,18 @@
 mysql-coworking:
-  image: mysql:latest
+  image: mysql
+  volumes:
+  - ./mysql/my-custom.cnf:/etc/mysql/conf.d/custom.cnf
+  - ./mysql/script.sql:/docker-entrypoint-initdb.d/script.sql
   environment:
     MYSQL_ROOT_PASSWORD: password
     MYSQL_DATABASE: coworking
+  ports:
+  - 3306:3306
 pma:
   image: phpmyadmin/phpmyadmin
   links:
   - mysql-coworking
   ports:
-    - 80:80
+  - 80:80
   environment:
     PMA_HOST: mysql-coworking

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+mysql-coworking:
+  image: mysql:latest
+  environment:
+    MYSQL_ROOT_PASSWORD: password
+    MYSQL_DATABASE: coworking
+pma:
+  image: phpmyadmin/phpmyadmin
+  links:
+  - mysql-coworking
+  ports:
+    - 80:80
+  environment:
+    PMA_HOST: mysql-coworking

--- a/src/main/docker/mysql/my-custom.cnf
+++ b/src/main/docker/mysql/my-custom.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+skip-character-set-client-handshake

--- a/src/main/docker/mysql/script.sql
+++ b/src/main/docker/mysql/script.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `coworking`.`user` ( 
+    `id` SERIAL NOT NULL AUTO_INCREMENT COMMENT 'identify a user unequivocally',
+    `email` VARCHAR(255) NOT NULL COMMENT 'contact user, send private information or reset password',
+    `password` CHAR(60) BINARY NOT NULL COMMENT 'cryptographic hash of user password',
+    `lastname` VARCHAR(100) NOT NULL COMMENT 'family name used to address user in communication',
+    `firstname` VARCHAR(100) NOT NULL COMMENT 'first name used to address user in communication',
+    PRIMARY KEY (`id`),
+    UNIQUE (`email`)) ENGINE = InnoDB;
+
+INSERT INTO `coworking`.`user` (`id`, `email`, `password`, `lastname`, `firstname`) VALUES
+    (NULL, 'adrien.pierre.horgnies@gmail.com', '$2y$10$rbE59kdmEfSgKQL8cvRBHuRzKktjVXRpICafsx5d7/SITS4zEcInS', 'Horgnies', 'Adrien'),
+    (NULL, 'baran.1702.student@ifosupwavre.be', '$2y$10$7kohD8s7JhspL5goSZ1JT.f5jcVXvOk4Vjt.6GATWQi/lnsJuoklK', 'Baran', 'Katia'),
+    (NULL, 'chan.1804.student@ifosupwavre.be', '$2y$10$78lnxSlBaWpyTd7Z/W7tu.NaaQN4fgZUBSOJM5THmKFtVc/l5VyLC', 'Chan', 'Phirum'),
+    (NULL, 'thiry.2906.student@ifosupwavre.be', '$2y$10$ny6EgjXFr8ZGHf9IQZ7L0uLLoNQPh9Ilbeih3fgSjORNis6QOq4BW', 'Thiry', 'Stéphane'),
+    (NULL, 'stephane.huguier@ifosupwavre.be', '$2y$10$F6G9d2X8jWvuTNYZb1Jme.rSAK4fLkliOhMJsAoarGPv/uHoUJ43q', 'Huguier', 'Stéphane'),
+    (NULL, 'xavier.jeunejean@ifosupwavre.be', '$2y$10$ruYha1JkYyMkFimirQiuO.qEFeVDnIR7fhek7PFhCM2I/tvL5P1Ky', 'Jeunejean', 'Xavier')


### PR DESCRIPTION
From now on, we'll be able to use our database from a docker container. It uses a standard mysql image which a bit of configuration

**To approve this merge request, ensure you are able to run the docker-compose and to browse the database using phpmyadmin.**. Make any modification to `src/main/docker/mysql/script.sql` and the modification should appear when you're inspecting the database from phpmyadmin (ex. add in a new entry in the insert statement), **after recreating the mysql container**.

### Run the docker-compose
A docker-compose is provided, it includes the database and phpmyadmin client.

1. Download and install docker (requires Linux or MS Windows 10 Pro or above)
2. Run the docker-compose using `docker-compose up` from the terminal, provided that the terminal run from the directory `src/main/docker`. Similarly, you can use intelliJ Docker plugin:
    1. Inside Docker settings, check the option "Expose daemon on tcp://localhost:2375 without tls" and configure intelliJ to use this TCP socket (open settings and search Docker).
    2. Inside IntelliJ Docker plugin settings (open IntelliJ settings [`ctrl + alt + S`] and search Docker), use "TCP socket" and let default value. If page is empty, click on the `+` symbol.
    3. Right click the `docker-compose.yml` file and choose "Run 'Docker/docker-compos'".

### Stop the docker-compose
Be aware that stopping a container doesn't change the image it is using.

- If you run it from a terminal, press `ctrl + C`.
- From another terminal, you can stop any container individually, ex.: `docker stop docker_pma_1`. Where the argument can be the name or id of any running container.
- From the Docker plugin tab, you can right click on the Compose and choose Stop.

### Destroy the docker-compose
By that, I mean destroying every container included in said docker-compose.

- If you run it from a terminal, run the command `docker-compose down`.
- From the Docker plugin tab, right click "Compose" and choose "Down".